### PR TITLE
[feat] add fallout 4 handler for ms game pass to steam save migration

### DIFF
--- a/XgpSaveTools/SaveHandlers/Impl/Fallout4Handler.cs
+++ b/XgpSaveTools/SaveHandlers/Impl/Fallout4Handler.cs
@@ -1,0 +1,45 @@
+﻿using System.Text;
+using XgpSaveTools.Records;
+using static XgpSaveTools.Extensions.IoExtensions;
+
+namespace XgpSaveTools.SaveHandlers.Impl
+{
+    public class Fallout4Handler : ISaveHandler
+    {
+        public bool CanHandle(string handlerName) => handlerName == "fallout-4";
+
+        public IEnumerable<SaveFile> GetSaveEntries(List<ContainerMetaFile> containers, HandlerArgs? args)
+        {
+            var outDir = Path.Combine(CreateTempFolder().FullName, "Fallout4");
+            Directory.CreateDirectory(outDir);
+            var padStr = Encoding.ASCII.GetBytes(string.Concat(Enumerable.Repeat("padding\0", 2)));
+
+            foreach (var c in containers)
+            {
+                var path = c.Name.Replace("\\", "/");
+                if (!path.StartsWith("Saves/")) continue;
+                var saveName = Path.GetFileName(path);
+                var parts = new SortedDictionary<int, string>();
+                bool isNew = c.Files.Any(f => f.Name == "toc");
+                foreach (var f in c.Files)
+                {
+                    if (f.Name == "toc") continue;
+                    int idx = isNew
+                        ? int.Parse(f.Name.Replace("ChunkData", ""))
+                        : (f.Name == "FO4_SAVEGAME" ? 0 : int.Parse(f.Name.TrimStart('P')) + 1);
+                    parts[idx] = f.Path;
+                }
+                var outFile = Path.Combine(outDir, saveName);
+                using var outFs = File.OpenWrite(outFile);
+                foreach (var kv in parts)
+                {
+                    var data = File.ReadAllBytes(kv.Value);
+                    outFs.Write(data, 0, data.Length);
+                    var pad = 16 - (data.Length % 16);
+                    if (pad < 16) outFs.Write(padStr, 0, pad);
+                }
+                yield return new(saveName, outFile);
+            }
+        }
+    }
+}

--- a/XgpSaveTools/SaveHandlers/SaveHandlerFactory.cs
+++ b/XgpSaveTools/SaveHandlers/SaveHandlerFactory.cs
@@ -15,6 +15,7 @@ namespace XgpSaveTools.SaveHandlers
             new OneContainerManyFilesFolderHandler(),
             new ControlHandler(),
             new StarfieldHandler(),
+            new Fallout4Handler(),
             new ScornHandler(),
             new Persona3ReloadHandler(),
             new ArcadeParadiseHandler(),

--- a/XgpSaveTools/games.json
+++ b/XgpSaveTools/games.json
@@ -209,6 +209,12 @@
       "package": "BethesdaSoftworks.ProjectGold_3275kfvn8vcwc",
       "handler": "starfield"
     },
+    // Fallout 4
+    {
+      "name": "Fallout 4",
+      "package": "BethesdaSoftworks.Fallout4-CoreGame_3275kfvn8vcwc",
+      "handler": "fallout-4"
+    },
     // Lies of P
     {
       "name": "Lies of P",


### PR DESCRIPTION
## Summary
Adds support for Fallout 4 save extraction from Xbox Game Pass to Steam/PC.

## Implementation
The `Fallout4Handler` follows the same pattern as `StarfieldHandler` since both games use Bethesda's chunked save format:
- Save files are fragmented into `ChunkData0` (and potentially ChunkData1, ChunkData2, etc.)
- Metadata stored in `toc` file
- Requires 16-byte padding between chunks during reassembly

## Changes
- **New file**: `XgpSaveTools/SaveHandlers/Impl/Fallout4Handler.cs`
- **Modified**: `XgpSaveTools/SaveHandlers/SaveHandlerFactory.cs` (registered handler)
- **Modified**: `XgpSaveTools/games.json` (added Fallout 4 entry)

## Testing
Successfully tested with real save data:
- **Package**: `BethesdaSoftworks.Fallout4-CoreGame_3275kfvn8vcwc`
- **Saves extracted**: 75 save files (autosaves, quicksaves, manual saves)
- **Result**: All saves loaded successfully in Steam version of Fallout 4
- **Save sizes**: Ranged from 4MB to 13MB
- **Game versions tested**: Saves from game versions 1.10.102 through 1.10.124

### Complete Console Output
```
========================================

Xbox Game Pass Save Tools

========================================



Select Option

1) Scan Games

2) Enter Path

3) Exit

Enter selection: 1




Select a game:

1) Fallout 4

2) Show Unregistered (7)

Enter selection(or '0' to go back): 1



Select user folder:

1) 000901FE3BF7B174

Enter selection(or '0' to go back): 1



Select operation:

1) Extract Files

2) Replace/Delete Entries

3) Open Directory

Enter selection(or '0' to go back): 1



- Fallout 4

Using Fallout4Handler

Saving files for user 000901FE3BF7B174:

  - Autosave1_30066640M5469676166_Vault111Cryo_000033_20221205060850_1_2.fos

  - Autosave1_97B2FBAEM5469676166_Commonwealth_011213_20260122083805_28_2.fos

  - Autosave2_30066640M5469676166_SanctuaryHillsWorld_000018_20221205054130_1_2.fos

  - Autosave2_97B2FBAEM5469676166_RailroadHQEscapeTunnel_011210_20260122081612_28_2.fos

  - Autosave3_30066640M5469676166_Vault111Cryo_000025_20221205055209_1_2.fos

  - Autosave3_97B2FBAEM5469676166_Commonwealth_011211_20260122082457_28_2.fos

  - Exitsave0_97B2FBAEM5469676166_OldNorthChurch01_011203_20260121034623_28_2.fos

  - Quicksave0_97B2FBAEM5469676166_Commonwealth_011214_20260122083921_28_2.fos

  - Save10_97B2FBAEM5469676166_Commonwealth_000348_20221206071452_8_2.fos

  - Save11_97B2FBAEM5469676166_Commonwealth_000504_20221208095841_8_2.fos

  - Save12_97B2FBAEM5469676166_Commonwealth_000518_20221208101409_8_2.fos

  - Save13_97B2FBAEM5469676166_Commonwealth_000558_20221208105432_9_2.fos

  - Save14_97B2FBAEM5469676166_Commonwealth_000606_20221208110316_9_2.fos

  - Save15_97B2FBAEM5469676166_Commonwealth_000648_20221209050632_10_2.fos

  - Save16_97B2FBAEM5469676166_Commonwealth_000648_20221209082947_10_2.fos

  - Save17_97B2FBAEM5469676166_Commonwealth_000652_20221209084956_10_2.fos

  - Save18_97B2FBAEM5469676166_BackStreetApparel01_000658_20221209090023_10_2.fos

  - Save19_97B2FBAEM5469676166_BackStreetApparel01_000704_20221209090750_10_2.fos

  - Save1_30066640M5469676166_Vault111Cryo_000034_20221205060946_1_2.fos

  - Save1_97B2FBAEM5469676166_Commonwealth_000039_20221205061458_1_2.fos

  - Save20_97B2FBAEM5469676166_WestonWaterTreatment01_000718_20221209092419_10_2.fos

  - Save21_97B2FBAEM5469676166_WestonWaterTreatment01_000728_20221209093428_10_2.fos

  - Save22_97B2FBAEM5469676166_WestonWaterTreatment01_000734_20221209094427_11_2.fos

  - Save23_97B2FBAEM5469676166_SuperDuperMart01_000751_20221209111121_11_2.fos

  - Save24_97B2FBAEM5469676166_DiamondCity_000722_20221217122219_11_2.fos

  - Save25_97B2FBAEM5469676166_Commonwealth_000735_20221220044913_11_2.fos

  - Save26_97B2FBAEM5469676166_WestonWaterTreatment01_000752_20221220050627_11_2.fos

  - Save27_97B2FBAEM5469676166_DmndDugoutInn01_000831_20221220055103_11_2.fos

  - Save28_97B2FBAEM5469676166_DiamondCity_001045_20221220082646_12_2.fos

  - Save29_97B2FBAEM5469676166_DiamondCity_001055_20221221071840_12_2.fos

  - Save2_97B2FBAEM5469676166_Commonwealth_000045_20221205062719_1_2.fos

  - Save30_97B2FBAEM5469676166_DiamondCity_001108_20221221073419_12_2.fos

  - Save31_97B2FBAEM5469676166_DiamondCity_001113_20221221080321_12_2.fos

  - Save32_97B2FBAEM5469676166_Commonwealth_001132_20221221084029_12_2.fos

  - Save33_97B2FBAEM5469676166_Commonwealth_001202_20221221091031_13_2.fos

  - Save34_97B2FBAEM5469676166_Commonwealth_001221_20221221093018_13_2.fos

  - Save35_97B2FBAEM5469676166_Commonwealth_001223_20230105082938_13_2.fos

  - Save36_97B2FBAEM5469676166_GoodneighborHotelRexford_001417_20230112065930_14_2.fos

  - Save37_97B2FBAEM5469676166_TheBigDig01_001538_20230112083706_15_2.fos

  - Save38_97B2FBAEM5469676166_TheBigDig01_001549_20230112084830_15_2.fos

  - Save39_97B2FBAEM5469676166_ParsonsState03_001639_20230112094222_16_2.fos

  - Save3_97B2FBAEM5469676166_Commonwealth_000135_20221205075934_4_2.fos

  - Save40_97B2FBAEM5469676166_Commonwealth_001748_20230112105129_16_2.fos

  - Save41_97B2FBAEM5469676166_Commonwealth_001916_20230112122230_17_2.fos

  - Save42_97B2FBAEM5469676166_Commonwealth_001922_20230113063802_17_2.fos

  - Save43_97B2FBAEM5469676166_Commonwealth_001928_20230113064339_17_2.fos

  - Save44_97B2FBAEM5469676166_NationalGuardTrainingYard03_002044_20230921064056_18_2.fos

  - Save45_97B2FBAEM5469676166_Commonwealth_002132_20230921074130_18_2.fos

  - Save46_97B2FBAEM5469676166_CambridgePD01_002139_20230921074822_18_2.fos

  - Save47_97B2FBAEM5469676166_Commonwealth_002313_20230923125924_20_2.fos

  - Save48_97B2FBAEM5469676166_Commonwealth_010016_20230925054924_20_2.fos

  - Save49_97B2FBAEM5469676166_Commonwealth_010018_20230925055151_20_2.fos

  - Save4_97B2FBAEM5469676166_USAFSatellite01_000138_20221205080813_4_2.fos

  - Save50_97B2FBAEM5469676166_DLC06VaultWorkshop_010052_20230926060039_21_2.fos

  - Save51_97B2FBAEM5469676166_DLC06VaultWorkshop_010140_20230926070350_23_2.fos

  - Save52_97B2FBAEM5469676166_Goodneighbor_010241_20230926081058_23_2.fos

  - Save53_97B2FBAEM5469676166_DiamondCity_010701_20230928085704_26_2.fos

  - Save54_97B2FBAEM5469676166_Switchboard_011133_20250716053044_28_2.fos

  - Save55_97B2FBAEM5469676166_OldNorthChurch01_011203_20250716060826_28_2.fos

  - Save56_97B2FBAEM5469676166_Commonwealth_011218_20250716062453_28_2.fos

  - Save57_97B2FBAEM5469676166_Commonwealth_011227_20250716064228_28_2.fos

  - Save58_97B2FBAEM5469676166_Commonwealth_011259_20250716071529_29_2.fos

  - Save59_97B2FBAEM5469676166_OldNorthChurch01_011203_20260121034616_28_2.fos

  - Save5_97B2FBAEM5469676166_ArcjetSystems02_000241_20221205092205_6_2.fos

  - Save60_97B2FBAEM5469676166_RailroadHQ01_011209_20260121051750_28_2.fos

  - Save61_97B2FBAEM5469676166_OldNorthChurch01_011215_20260121074611_28_2.fos

  - Save62_97B2FBAEM5469676166_Commonwealth_011219_20260121075116_28_2.fos

  - Save63_97B2FBAEM5469676166_Commonwealth_011222_20260121075355_28_2.fos

  - Save64_97B2FBAEM5469676166_Commonwealth_011223_20260122052730_28_2.fos

  - Save65_97B2FBAEM5469676166_Commonwealth_011224_20260122055217_28_2.fos

  - Save66_97B2FBAEM5469676166_RailroadHQ01_011208_20260122080909_28_2.fos

  - Save6_97B2FBAEM5469676166_ArcjetSystems02_000247_20221205214911_6_2.fos

  - Save7_97B2FBAEM5469676166_Commonwealth_000254_20221205215715_7_2.fos

  - Save8_97B2FBAEM5469676166_CambridgePD01_000310_20221206004348_7_2.fos

  - Save9_97B2FBAEM5469676166_Commonwealth_000340_20221206070556_8_2.fos

Save files written to "fallout_4_000901FE3BF7B174_2026-01-22_23-37-15.zip"



[OK] 75 files extracted



Press any key to continue...
```

## Use Case
Enables players to migrate 100+ hour Fallout 4 playthroughs from Xbox Game Pass (30fps) to Steam (120fps) while preserving all progress, allowing access to F4SE, Buffout crash logging, and full Nexus Mods support with version pinning.
